### PR TITLE
add 'create from selected tab' button

### DIFF
--- a/Source/manifest.json
+++ b/Source/manifest.json
@@ -17,6 +17,6 @@
     "manifest_version": 3,
     "permissions": [
         "storage",
-        "tabs"
+        "activeTab"
     ]
 }

--- a/Source/manifest.json
+++ b/Source/manifest.json
@@ -16,6 +16,7 @@
     },
     "manifest_version": 3,
     "permissions": [
-        "storage"
+        "storage",
+        "tabs"
     ]
 }

--- a/Source/popup.html
+++ b/Source/popup.html
@@ -52,6 +52,7 @@
             <div class="card-footer">
                 <div class="loading d-hide"></div>
                 <button class="btn btn-primary" id="shortURL">Create</button>
+                <button class="btn btn-primary" id="shortSelTab">Create from selected tab</button>
             </div><br>
             <div class="toast toast-success d-hide"><button class="btn btn-clear float-right"></button></div>
             <div style="float:bottom;" class="toast toast-success d-hide" id="copied">Copied!</div>

--- a/Source/src/popup.js
+++ b/Source/src/popup.js
@@ -1,4 +1,5 @@
 let generateBtn = document.querySelector("#shortURL");
+let generateSelTabBtn = document.querySelector("#shortSelTab");
 let shortbut = document.querySelector("#shortbut");
 let copyBtn = document.querySelector("#shortcopy");
 let copy = document.querySelector("#copied");
@@ -24,18 +25,24 @@ function urlValidate(url) {
   
 
 generateBtn.addEventListener('click', () => {
+    shortenUrl(api.value)
+})
+generateSelTabBtn.addEventListener('click', () => {
+    chrome.tabs.query({ active: true, lastFocusedWindow: true }).then(tab => {
+        tab = tab[0];
+        shortenUrl(tab.url)
+    })
+})
 
-    var copyText;
-
-    
-    if (api.value && urlValidate(api.value)) {
+function shortenUrl(longURL) {
+    if (longURL && urlValidate(longURL)) {
         loader.classList.remove('d-hide')
         chrome.storage.local.get(['API'], function (result) {
             fetch(url, {
                 method: "POST",
                 headers: headers,
                 body: JSON.stringify({
-                    "long_url": api.value,
+                    "long_url": longURL, 
                     "domain": "https://t.ly/",
                     "api_token": result.API
                 })
@@ -50,7 +57,7 @@ generateBtn.addEventListener('click', () => {
                         copy.classList.add('d-hide')
                     }, 2000)
 
-                    copyText=json.short_url;
+                    const copyText=json.short_url;
 
                     var dummy = document.createElement("textarea");
                     document.body.appendChild(dummy);
@@ -73,7 +80,7 @@ generateBtn.addEventListener('click', () => {
             toastError.classList.add('d-hide')
         }, 1500)
     }
-})
+}
 
 backBtn.addEventListener('click', () => {
     


### PR DESCRIPTION
Alright i did it.
![image](https://user-images.githubusercontent.com/53093333/197334673-ad7c35d9-2367-44ad-81cc-21321ea236e9.png)

~~I did have to add the 'tabs' permission, though, otherwise it can't access the URL of the current tab. This will show a permission prompt when installing the extension, if i remember correctly.~~ NVM i realized we could use the 'activeTab' permission, which is a lot more appropriate and doesn't prompt the user.
closes #20 