### PR TITLE
feature: add keyboard shortcut to open the extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ List of features available
 
 • Selected tab link copy button
 
+• Invoke the extension using keyboard shortcuts - `Ctrl+Shift+S` on Windows and `Command+Shift+S` on Mac
+
+
 
 ## Downloads
 

--- a/Source/manifest.json
+++ b/Source/manifest.json
@@ -18,5 +18,13 @@
     "permissions": [
         "storage",
         "activeTab"
-    ]
+    ],
+    "commands": {
+        "_execute_action": {
+          "suggested_key": {
+            "windows": "Ctrl+Shift+S",
+            "mac": "Command+Shift+S"
+          }
+        }
+      }
 }


### PR DESCRIPTION
The extension can now be invoked by using `Ctrl+Shift+S` on Windows and `Command+Shift+S` on Mac. The readme has also been updated.